### PR TITLE
Add Sequelize database setup and basic models

### DIFF
--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -1,0 +1,16 @@
+require('dotenv').config();
+const { Sequelize } = require('sequelize');
+
+const sequelize = new Sequelize(
+  process.env.DB_NAME,
+  process.env.DB_USER,
+  process.env.DB_PASSWORD,
+  {
+    host: process.env.DB_HOST || 'localhost',
+    port: process.env.DB_PORT || 3306,
+    dialect: 'mysql',
+    logging: false,
+  }
+);
+
+module.exports = { sequelize };

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const { sequelize } = require('./models');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -11,6 +12,11 @@ app.use(express.json());
 app.get('/', (req, res) => {
   res.send('Server is running');
 });
+
+sequelize
+  .authenticate()
+  .then(() => console.log('Database connected'))
+  .catch(err => console.error('Database connection error:', err));
 
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);

--- a/backend/models/document.js
+++ b/backend/models/document.js
@@ -1,0 +1,23 @@
+module.exports = (sequelize, DataTypes) => {
+  const Document = sequelize.define('Document', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    path: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  });
+
+  Document.associate = models => {
+    Document.belongsTo(models.User, { foreignKey: 'userId' });
+  };
+
+  return Document;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,0 +1,16 @@
+const { sequelize } = require('../config/database');
+const { DataTypes } = require('sequelize');
+
+const models = {
+  Role: require('./role')(sequelize, DataTypes),
+  User: require('./user')(sequelize, DataTypes),
+  ONG: require('./ong')(sequelize, DataTypes),
+  Withdrawal: require('./withdrawal')(sequelize, DataTypes),
+  Document: require('./document')(sequelize, DataTypes),
+};
+
+Object.values(models)
+  .filter(model => typeof model.associate === 'function')
+  .forEach(model => model.associate(models));
+
+module.exports = { sequelize, ...models };

--- a/backend/models/ong.js
+++ b/backend/models/ong.js
@@ -1,0 +1,22 @@
+module.exports = (sequelize, DataTypes) => {
+  const ONG = sequelize.define('ONG', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+    },
+  });
+
+  ONG.associate = models => {
+    ONG.hasMany(models.Withdrawal, { foreignKey: 'ongId' });
+  };
+
+  return ONG;
+};

--- a/backend/models/role.js
+++ b/backend/models/role.js
@@ -1,0 +1,19 @@
+module.exports = (sequelize, DataTypes) => {
+  const Role = sequelize.define('Role', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  });
+
+  Role.associate = models => {
+    Role.hasMany(models.User, { foreignKey: 'roleId' });
+  };
+
+  return Role;
+};

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,0 +1,30 @@
+module.exports = (sequelize, DataTypes) => {
+  const User = sequelize.define('User', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    email: {
+      type: DataTypes.STRING,
+      unique: true,
+      allowNull: false,
+    },
+    password: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  });
+
+  User.associate = models => {
+    User.belongsTo(models.Role, { foreignKey: 'roleId' });
+    User.hasMany(models.Document, { foreignKey: 'userId' });
+    User.hasMany(models.Withdrawal, { foreignKey: 'userId' });
+  };
+
+  return User;
+};

--- a/backend/models/withdrawal.js
+++ b/backend/models/withdrawal.js
@@ -1,0 +1,20 @@
+module.exports = (sequelize, DataTypes) => {
+  const Withdrawal = sequelize.define('Withdrawal', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    amount: {
+      type: DataTypes.DECIMAL(10,2),
+      allowNull: false,
+    },
+  });
+
+  Withdrawal.associate = models => {
+    Withdrawal.belongsTo(models.User, { foreignKey: 'userId' });
+    Withdrawal.belongsTo(models.ONG, { foreignKey: 'ongId' });
+  };
+
+  return Withdrawal;
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "sync-db": "node sync.js"
   },
   "keywords": [],
   "author": "",
@@ -13,6 +14,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
-    "dotenv": "^16.0.3"
+    "dotenv": "^16.0.3",
+    "mysql2": "^3.9.2",
+    "sequelize": "^6.37.1"
   }
 }

--- a/backend/sync.js
+++ b/backend/sync.js
@@ -1,0 +1,12 @@
+const { sequelize } = require('./models');
+
+(async () => {
+  try {
+    await sequelize.sync();
+    console.log('Database synchronized');
+  } catch (err) {
+    console.error('Error syncing database:', err);
+  } finally {
+    await sequelize.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- install `mysql2` and `sequelize`
- add connection helper that reads env vars
- define basic models for User, Role, ONG, Withdrawal and Document
- export models from `models/index.js`
- add script to sync database and integrate DB connection in the server

## Testing
- `npm test` *(fails: no test specified)*
- `npm run sync-db` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686e8c4cd5cc8331b557398154602184