### PR TITLE
Add authentication API with token middleware

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -2,12 +2,15 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const { sequelize } = require('./models');
+const authRoutes = require('./routes/auth');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(cors());
 app.use(express.json());
+
+app.use('/auth', authRoutes);
 
 app.get('/', (req, res) => {
   res.send('Server is running');

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -1,0 +1,19 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) {
+    return res.status(401).json({ error: 'No token provided' });
+  }
+
+  const token = authHeader.split(' ')[1] || authHeader;
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    console.error(err);
+    res.status(401).json({ error: 'Invalid token' });
+  }
+};

--- a/backend/middlewares/roleMiddleware.js
+++ b/backend/middlewares/roleMiddleware.js
@@ -1,0 +1,13 @@
+module.exports = (allowedRoles = []) => {
+  return (req, res, next) => {
+    if (!req.user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    if (!allowedRoles.includes(req.user.role)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    next();
+  };
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,5 +17,7 @@
     "dotenv": "^16.0.3",
     "mysql2": "^3.9.2",
     "sequelize": "^6.37.1"
+    ,"bcrypt": "^5.1.0"
+    ,"jsonwebtoken": "^9.0.0"
   }
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,79 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const router = express.Router();
+
+const { User, Role } = require('../models');
+
+// User registration
+router.post('/register', async (req, res) => {
+  try {
+    const { name, email, password, role } = req.body;
+    if (!name || !email || !password || !role) {
+      return res.status(400).json({ error: 'Missing fields' });
+    }
+
+    const existing = await User.findOne({ where: { email } });
+    if (existing) {
+      return res.status(409).json({ error: 'Email already registered' });
+    }
+
+    const roleRecord = await Role.findOne({ where: { name: role } });
+    if (!roleRecord) {
+      return res.status(400).json({ error: 'Invalid role' });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    const user = await User.create({
+      name,
+      email,
+      password: hashedPassword,
+      roleId: roleRecord.id,
+    });
+
+    const token = jwt.sign(
+      { id: user.id, role: roleRecord.name },
+      process.env.JWT_SECRET || 'secret',
+      { expiresIn: '1d' }
+    );
+
+    res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// User login
+router.post('/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ error: 'Missing fields' });
+    }
+
+    const user = await User.findOne({ where: { email }, include: Role });
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+
+    const token = jwt.sign(
+      { id: user.id, role: user.Role ? user.Role.name : null },
+      process.env.JWT_SECRET || 'secret',
+      { expiresIn: '1d' }
+    );
+
+    res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add bcrypt and jsonwebtoken to backend package
- create `/auth/register` and `/auth/login` endpoints
- create authMiddleware to validate JWT tokens
- create roleMiddleware to enforce role based access
- hook auth routes from express server

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install` *(fails: E403 Forbidden - GET https://registry.npmjs.org/bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_686e8e1de22c83319d23663a456ab42f