### PR TITLE
Add ONG registration endpoints and model update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+backend/uploads/

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,14 +3,17 @@ const express = require('express');
 const cors = require('cors');
 const { sequelize } = require('./models');
 const authRoutes = require('./routes/auth');
+const ongRoutes = require('./routes/ong');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(cors());
 app.use(express.json());
+app.use('/uploads', express.static('backend/uploads'));
 
 app.use('/auth', authRoutes);
+app.use('/ongs', ongRoutes);
 
 app.get('/', (req, res) => {
   res.send('Server is running');

--- a/backend/models/ong.js
+++ b/backend/models/ong.js
@@ -12,6 +12,25 @@ module.exports = (sequelize, DataTypes) => {
     description: {
       type: DataTypes.TEXT,
     },
+    phone: {
+      type: DataTypes.STRING,
+    },
+    email: {
+      type: DataTypes.STRING,
+    },
+    address: {
+      type: DataTypes.STRING,
+    },
+    statute: {
+      type: DataTypes.STRING,
+    },
+    documents: {
+      type: DataTypes.STRING,
+    },
+    status: {
+      type: DataTypes.ENUM('pendiente', 'aprobada', 'rechazada'),
+      defaultValue: 'pendiente',
+    },
   });
 
   ONG.associate = models => {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,8 +16,9 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "mysql2": "^3.9.2",
-    "sequelize": "^6.37.1"
-    ,"bcrypt": "^5.1.0"
-    ,"jsonwebtoken": "^9.0.0"
+    "sequelize": "^6.37.1",
+    "bcrypt": "^5.1.0",
+    "jsonwebtoken": "^9.0.0",
+    "multer": "^1.4.5"
   }
 }

--- a/backend/routes/ong.js
+++ b/backend/routes/ong.js
@@ -1,0 +1,75 @@
+const express = require('express');
+const path = require('path');
+const multer = require('multer');
+const { ONG } = require('../models');
+const auth = require('../middlewares/authMiddleware');
+const role = require('../middlewares/roleMiddleware');
+
+const router = express.Router();
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, path.join(__dirname, '../uploads'));
+  },
+  filename: (req, file, cb) => {
+    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, unique + '-' + file.originalname);
+  }
+});
+
+const upload = multer({ storage });
+
+// Register ONG
+router.post('/', upload.fields([{ name: 'statute', maxCount: 1 }, { name: 'documents', maxCount: 1 }]), async (req, res) => {
+  try {
+    const { name, description, phone, email, address } = req.body;
+    const statute = req.files['statute'] ? req.files['statute'][0].filename : null;
+    const documents = req.files['documents'] ? req.files['documents'][0].filename : null;
+    const ong = await ONG.create({ name, description, phone, email, address, statute, documents });
+    res.status(201).json(ong);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Get pending ONGs (admin only)
+router.get('/pending', auth, role(['admin']), async (req, res) => {
+  try {
+    const list = await ONG.findAll({ where: { status: 'pendiente' } });
+    res.json(list);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Approve ONG (admin only)
+router.post('/:id/approve', auth, role(['admin']), async (req, res) => {
+  try {
+    const ong = await ONG.findByPk(req.params.id);
+    if (!ong) return res.status(404).json({ error: 'Not found' });
+    ong.status = 'aprobada';
+    await ong.save();
+    res.json(ong);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Reject ONG (admin only)
+router.post('/:id/reject', auth, role(['admin']), async (req, res) => {
+  try {
+    const ong = await ONG.findByPk(req.params.id);
+    if (!ong) return res.status(404).json({ error: 'Not found' });
+    ong.status = 'rechazada';
+    await ong.save();
+    res.json(ong);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- expand ONG model with contact info and status fields
- add multer dependency and ignore uploads
- expose /ongs routes with registration and admin actions
- serve uploaded files from backend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e8f558a1083319d74953f3f63a3be