### PR TITLE
Implement withdrawal management and stock tracking

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const { sequelize } = require('./models');
 const authRoutes = require('./routes/auth');
 const ongRoutes = require('./routes/ong');
+const withdrawalRoutes = require('./routes/withdrawal');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -14,6 +15,7 @@ app.use('/uploads', express.static('backend/uploads'));
 
 app.use('/auth', authRoutes);
 app.use('/ongs', ongRoutes);
+app.use('/withdrawals', withdrawalRoutes);
 
 app.get('/', (req, res) => {
   res.send('Server is running');

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -6,6 +6,7 @@ const models = {
   User: require('./user')(sequelize, DataTypes),
   ONG: require('./ong')(sequelize, DataTypes),
   Withdrawal: require('./withdrawal')(sequelize, DataTypes),
+  Stock: require('./stock')(sequelize, DataTypes),
   Document: require('./document')(sequelize, DataTypes),
 };
 

--- a/backend/models/stock.js
+++ b/backend/models/stock.js
@@ -1,0 +1,24 @@
+module.exports = (sequelize, DataTypes) => {
+  const Stock = sequelize.define('Stock', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    variety: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    quantity: {
+      type: DataTypes.DECIMAL(10,2),
+      allowNull: false,
+      defaultValue: 0,
+    },
+  });
+
+  Stock.associate = models => {
+    Stock.belongsTo(models.ONG, { foreignKey: 'ongId' });
+  };
+
+  return Stock;
+};

--- a/backend/models/withdrawal.js
+++ b/backend/models/withdrawal.js
@@ -9,6 +9,22 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.DECIMAL(10,2),
       allowNull: false,
     },
+    variety: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    date: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    reason: {
+      type: DataTypes.TEXT,
+    },
+    status: {
+      type: DataTypes.ENUM('pendiente', 'aprobado', 'rechazado'),
+      defaultValue: 'pendiente',
+    }
   });
 
   Withdrawal.associate = models => {

--- a/backend/routes/withdrawal.js
+++ b/backend/routes/withdrawal.js
@@ -1,0 +1,79 @@
+const express = require('express');
+const router = express.Router();
+
+const { Withdrawal, Stock } = require('../models');
+const auth = require('../middlewares/authMiddleware');
+const role = require('../middlewares/roleMiddleware');
+
+// Create withdrawal request
+router.post('/', auth, async (req, res) => {
+  try {
+    const { amount, variety, ongId, reason } = req.body;
+    if (!amount || !variety || !ongId) {
+      return res.status(400).json({ error: 'Missing fields' });
+    }
+
+    const stock = await Stock.findOne({ where: { ongId, variety } });
+    if (!stock || parseFloat(stock.quantity) < parseFloat(amount)) {
+      return res.status(400).json({ error: 'Insufficient stock' });
+    }
+
+    stock.quantity = parseFloat(stock.quantity) - parseFloat(amount);
+    await stock.save();
+
+    const withdrawal = await Withdrawal.create({
+      userId: req.user.id,
+      ongId,
+      amount,
+      variety,
+      reason,
+    });
+
+    res.status(201).json(withdrawal);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Update withdrawal status (admin only)
+router.put('/:id', auth, role(['admin']), async (req, res) => {
+  try {
+    const { status } = req.body;
+    const withdrawal = await Withdrawal.findByPk(req.params.id);
+    if (!withdrawal) return res.status(404).json({ error: 'Not found' });
+
+    if (status === 'rechazado' && withdrawal.status === 'pendiente') {
+      const stock = await Stock.findOne({ where: { ongId: withdrawal.ongId, variety: withdrawal.variety } });
+      if (stock) {
+        stock.quantity = parseFloat(stock.quantity) + parseFloat(withdrawal.amount);
+        await stock.save();
+      }
+    }
+
+    withdrawal.status = status;
+    await withdrawal.save();
+    res.json(withdrawal);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Get withdrawal history
+router.get('/', auth, async (req, res) => {
+  try {
+    let list;
+    if (req.user.role === 'admin') {
+      list = await Withdrawal.findAll();
+    } else {
+      list = await Withdrawal.findAll({ where: { userId: req.user.id } });
+    }
+    res.json(list);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Stock model for inventory by variety
- expand Withdrawal model with extra fields
- create routes to request withdrawals, change status and list history
- wire up new endpoints in server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e920b6d888331bf413ec104702980