### PR TITLE
Implement doctor-patient relations

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5,6 +5,7 @@ const { sequelize } = require('./models');
 const authRoutes = require('./routes/auth');
 const ongRoutes = require('./routes/ong');
 const withdrawalRoutes = require('./routes/withdrawal');
+const patientRoutes = require('./routes/patient');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -16,6 +17,7 @@ app.use('/uploads', express.static('backend/uploads'));
 app.use('/auth', authRoutes);
 app.use('/ongs', ongRoutes);
 app.use('/withdrawals', withdrawalRoutes);
+app.use('/patients', patientRoutes);
 
 app.get('/', (req, res) => {
   res.send('Server is running');

--- a/backend/models/doctorPatient.js
+++ b/backend/models/doctorPatient.js
@@ -1,0 +1,19 @@
+module.exports = (sequelize, DataTypes) => {
+  const DoctorPatient = sequelize.define('DoctorPatient', {
+    doctorId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    patientId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  }, { timestamps: false });
+
+  DoctorPatient.associate = models => {
+    DoctorPatient.belongsTo(models.User, { as: 'Doctor', foreignKey: 'doctorId' });
+    DoctorPatient.belongsTo(models.User, { as: 'Patient', foreignKey: 'patientId' });
+  };
+
+  return DoctorPatient;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -8,6 +8,8 @@ const models = {
   Withdrawal: require('./withdrawal')(sequelize, DataTypes),
   Stock: require('./stock')(sequelize, DataTypes),
   Document: require('./document')(sequelize, DataTypes),
+  DoctorPatient: require('./doctorPatient')(sequelize, DataTypes),
+  MedicalDoc: require('./medicalDoc')(sequelize, DataTypes),
 };
 
 Object.values(models)

--- a/backend/models/medicalDoc.js
+++ b/backend/models/medicalDoc.js
@@ -1,0 +1,24 @@
+module.exports = (sequelize, DataTypes) => {
+  const MedicalDoc = sequelize.define('MedicalDoc', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    path: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  });
+
+  MedicalDoc.associate = models => {
+    MedicalDoc.belongsTo(models.User, { as: 'Doctor', foreignKey: 'doctorId' });
+    MedicalDoc.belongsTo(models.User, { as: 'Patient', foreignKey: 'patientId' });
+  };
+
+  return MedicalDoc;
+};

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -18,12 +18,29 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
     },
+    authorizedUse: {
+      type: DataTypes.STRING,
+    },
   });
 
   User.associate = models => {
     User.belongsTo(models.Role, { foreignKey: 'roleId' });
     User.hasMany(models.Document, { foreignKey: 'userId' });
     User.hasMany(models.Withdrawal, { foreignKey: 'userId' });
+    User.belongsToMany(models.User, {
+      as: 'Patients',
+      through: models.DoctorPatient,
+      foreignKey: 'doctorId',
+      otherKey: 'patientId',
+    });
+    User.belongsToMany(models.User, {
+      as: 'Doctors',
+      through: models.DoctorPatient,
+      foreignKey: 'patientId',
+      otherKey: 'doctorId',
+    });
+    User.hasMany(models.MedicalDoc, { as: 'DoctorDocs', foreignKey: 'doctorId' });
+    User.hasMany(models.MedicalDoc, { as: 'PatientDocs', foreignKey: 'patientId' });
   };
 
   return User;

--- a/backend/routes/patient.js
+++ b/backend/routes/patient.js
@@ -1,0 +1,81 @@
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const path = require('path');
+
+const { User, DoctorPatient, MedicalDoc } = require('../models');
+const auth = require('../middlewares/authMiddleware');
+const role = require('../middlewares/roleMiddleware');
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, path.join(__dirname, '../uploads'));
+  },
+  filename: (req, file, cb) => {
+    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, unique + '-' + file.originalname);
+  }
+});
+
+const upload = multer({ storage });
+
+// Associate patient with doctor
+router.post('/', auth, role(['doctor']), async (req, res) => {
+  try {
+    const { patientId } = req.body;
+    if (!patientId) return res.status(400).json({ error: 'Missing patientId' });
+    await DoctorPatient.findOrCreate({ where: { doctorId: req.user.id, patientId } });
+    res.sendStatus(201);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// List patients of the logged doctor
+router.get('/', auth, role(['doctor']), async (req, res) => {
+  try {
+    const relations = await DoctorPatient.findAll({ where: { doctorId: req.user.id }, include: [{ model: User, as: 'Patient' }] });
+    const list = relations.map(r => r.Patient);
+    res.json(list);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Update authorized use for a patient
+router.put('/:id/use', auth, role(['doctor']), async (req, res) => {
+  try {
+    const patient = await User.findByPk(req.params.id);
+    if (!patient) return res.status(404).json({ error: 'Not found' });
+    patient.authorizedUse = req.body.authorizedUse;
+    await patient.save();
+    res.json(patient);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Upload medical document for patient
+router.post('/medical-docs', auth, role(['doctor']), upload.single('file'), async (req, res) => {
+  try {
+    const { patientId, title } = req.body;
+    if (!patientId || !req.file || !title) {
+      return res.status(400).json({ error: 'Missing fields' });
+    }
+    const doc = await MedicalDoc.create({
+      doctorId: req.user.id,
+      patientId,
+      title,
+      path: req.file.filename,
+    });
+    res.status(201).json(doc);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create `DoctorPatient` and `MedicalDoc` models
- add `authorizedUse` field and associations in `User`
- add patient routes with medical-doc upload
- register patient routes in server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ea36941988331b0e158fdf6f54d8c