### PR TITLE
Configure API base URL in frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,4 +14,6 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
-  }}
+  },
+  "proxy": "http://localhost:3000"
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,15 @@
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3000';
+
 export async function apiFetch(path, { token, ...options } = {}) {
-  const headers = { 'Content-Type': 'application/json', ...(options.headers || {}) };
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(options.headers || {})
+  };
+
   if (token) headers['Authorization'] = `Bearer ${token}`;
-  const res = await fetch(path, { ...options, headers });
+
+  const res = await fetch(`${API_URL}${path}`, { ...options, headers });
+
   if (!res.ok) throw new Error('Request failed');
-  return res.json();
-}
+
+  return res.json();}


### PR DESCRIPTION
## Summary
- read API base URL from `REACT_APP_API_URL` env var
- forward unknown requests in dev using package.json `proxy`

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `CI=true npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec902210c83319c99d7e847ebf558