### PR TITLE
Add role seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ En la carpeta `backend` copiar el archivo `.env.example` a `.env` y completar lo
 cd backend
 npm install
 npm run sync-db
+npm run seed-roles
 npm start
 ```
+El script `npm run seed-roles` crea los roles básicos en la base de datos.
 
 ## Iniciar el frontend
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "sync-db": "node sync.js",
+    "seed-roles": "node seed-roles.js",
     "start": "node index.js"
   },
   "keywords": [],

--- a/backend/seed-roles.js
+++ b/backend/seed-roles.js
@@ -1,0 +1,19 @@
+require('dotenv').config();
+const { Role, sequelize } = require('./models');
+
+(async () => {
+  try {
+    const basicRoles = ['admin', 'doctor', 'legal', 'paciente'];
+    for (const name of basicRoles) {
+      const [role, created] = await Role.findOrCreate({ where: { name } });
+      if (created) {
+        console.log(`Rol '${name}' creado`);
+      }
+    }
+    console.log('Seed de roles completo');
+  } catch (err) {
+    console.error('Error al crear roles:', err);
+  } finally {
+    await sequelize.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- add `backend/seed-roles.js` to create base roles
- expose new npm script `seed-roles`
- document how to run it in the backend startup steps

## Testing
- `node --check backend/seed-roles.js`

------
https://chatgpt.com/codex/tasks/task_e_686eca58b6b0833198e0db72d22c0c68