### PR TITLE
Update frontend env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ En la carpeta `backend` copiar el archivo `.env.example` a `.env` y completar lo
 - `DB_PASSWORD`: contraseña del usuario.
 - `JWT_SECRET`: clave para firmar los tokens.
 
+En `frontend` también puede crearse un archivo `.env` (ver `.env.example`) con las siguientes variables:
+
+- `PORT`: puerto del servidor de desarrollo de React (por defecto 3001).
+- `REACT_APP_API_URL`: URL base del backend al que se realizarán las peticiones.
+
 ## Levantar el backend
 
 ```bash
@@ -31,7 +36,9 @@ El script `npm run seed-roles` crea los roles básicos en la base de datos.
 ```bash
 cd frontend
 npm install
-npm run dev
+PORT=3001 npm run dev
+
+Asegúrate de que `REACT_APP_API_URL` apunte a la URL del backend.
 ```
 
 ## Roles

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+PORT=3001
+REACT_APP_API_URL=http://localhost:3000


### PR DESCRIPTION
## Summary
- add example env vars for the React app
- document configuring PORT=3001 and REACT_APP_API_URL

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecb4f50788331aa26f87106b9bb37