### PR TITLE
Add ong ownership to several models

### DIFF
--- a/backend/models/doctorPatient.js
+++ b/backend/models/doctorPatient.js
@@ -8,11 +8,15 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
+    ongId: {
+      type: DataTypes.INTEGER,
+    },
   }, { timestamps: false });
 
   DoctorPatient.associate = models => {
     DoctorPatient.belongsTo(models.User, { as: 'Doctor', foreignKey: 'doctorId' });
     DoctorPatient.belongsTo(models.User, { as: 'Patient', foreignKey: 'patientId' });
+    DoctorPatient.belongsTo(models.ONG, { foreignKey: 'ongId' });
   };
 
   return DoctorPatient;

--- a/backend/models/document.js
+++ b/backend/models/document.js
@@ -13,10 +13,14 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
     },
+    ongId: {
+      type: DataTypes.INTEGER,
+    },
   });
 
   Document.associate = models => {
     Document.belongsTo(models.User, { foreignKey: 'userId' });
+    Document.belongsTo(models.ONG, { foreignKey: 'ongId' });
   };
 
   return Document;

--- a/backend/models/legalRecord.js
+++ b/backend/models/legalRecord.js
@@ -17,10 +17,14 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
+    ongId: {
+      type: DataTypes.INTEGER,
+    },
   });
 
   LegalRecord.associate = models => {
     LegalRecord.belongsTo(models.User, { as: 'Patient', foreignKey: 'patientId' });
+    LegalRecord.belongsTo(models.ONG, { foreignKey: 'ongId' });
   };
 
   return LegalRecord;

--- a/backend/models/medicalDoc.js
+++ b/backend/models/medicalDoc.js
@@ -13,11 +13,15 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
     },
+    ongId: {
+      type: DataTypes.INTEGER,
+    },
   });
 
   MedicalDoc.associate = models => {
     MedicalDoc.belongsTo(models.User, { as: 'Doctor', foreignKey: 'doctorId' });
     MedicalDoc.belongsTo(models.User, { as: 'Patient', foreignKey: 'patientId' });
+    MedicalDoc.belongsTo(models.ONG, { foreignKey: 'ongId' });
   };
 
   return MedicalDoc;

--- a/backend/models/ong.js
+++ b/backend/models/ong.js
@@ -35,6 +35,11 @@ module.exports = (sequelize, DataTypes) => {
 
   ONG.associate = models => {
     ONG.hasMany(models.Withdrawal, { foreignKey: 'ongId' });
+    ONG.hasMany(models.User, { foreignKey: 'ongId' });
+    ONG.hasMany(models.Document, { foreignKey: 'ongId' });
+    ONG.hasMany(models.MedicalDoc, { foreignKey: 'ongId' });
+    ONG.hasMany(models.LegalRecord, { foreignKey: 'ongId' });
+    ONG.hasMany(models.DoctorPatient, { foreignKey: 'ongId' });
   };
 
   return ONG;

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -24,10 +24,14 @@ module.exports = (sequelize, DataTypes) => {
     legalStatus: {
       type: DataTypes.STRING,
     },
+    ongId: {
+      type: DataTypes.INTEGER,
+    },
   });
 
   User.associate = models => {
     User.belongsTo(models.Role, { foreignKey: 'roleId' });
+    User.belongsTo(models.ONG, { foreignKey: 'ongId' });
     User.hasMany(models.Document, { foreignKey: 'userId' });
     User.hasMany(models.Withdrawal, { foreignKey: 'userId' });
     User.belongsToMany(models.User, {

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -33,7 +33,7 @@ router.post('/register', async (req, res) => {
     });
 
     const token = jwt.sign(
-      { id: user.id, role: roleRecord.name },
+      { id: user.id, role: roleRecord.name, ongId: user.ongId },
       process.env.JWT_SECRET || 'secret',
       { expiresIn: '1d' }
     );
@@ -64,7 +64,7 @@ router.post('/login', async (req, res) => {
     }
 
     const token = jwt.sign(
-      { id: user.id, role: user.Role ? user.Role.name : null },
+      { id: user.id, role: user.Role ? user.Role.name : null, ongId: user.ongId },
       process.env.JWT_SECRET || 'secret',
       { expiresIn: '1d' }
     );

--- a/backend/routes/legalRecord.js
+++ b/backend/routes/legalRecord.js
@@ -32,6 +32,7 @@ router.post('/', auth, role(['doctor']), upload.single('file'), async (req, res)
       type,
       date: date || new Date(),
       path: req.file ? req.file.filename : null,
+      ongId: req.user.ongId,
     });
 
     const patient = await User.findByPk(patientId);

--- a/backend/routes/patient.js
+++ b/backend/routes/patient.js
@@ -24,7 +24,10 @@ router.post('/', auth, role(['doctor']), async (req, res) => {
   try {
     const { patientId } = req.body;
     if (!patientId) return res.status(400).json({ error: 'Missing patientId' });
-    await DoctorPatient.findOrCreate({ where: { doctorId: req.user.id, patientId } });
+    await DoctorPatient.findOrCreate({
+      where: { doctorId: req.user.id, patientId },
+      defaults: { ongId: req.user.ongId }
+    });
     res.sendStatus(201);
   } catch (err) {
     console.error(err);
@@ -70,6 +73,7 @@ router.post('/medical-docs', auth, role(['doctor']), upload.single('file'), asyn
       patientId,
       title,
       path: req.file.filename,
+      ongId: req.user.ongId,
     });
     res.status(201).json(doc);
   } catch (err) {

--- a/backend/sync.js
+++ b/backend/sync.js
@@ -2,7 +2,7 @@ const { sequelize } = require('./models');
 
 (async () => {
   try {
-    await sequelize.sync();
+    await sequelize.sync({ alter: true });
     console.log('Database synchronized');
   } catch (err) {
     console.error('Error syncing database:', err);


### PR DESCRIPTION
## Summary
- include `ongId` foreign key in user, document, medicalDoc, legalRecord, and doctorPatient models
- relate these records to ONG in associations
- add ONG hasMany relations
- propagate `ongId` in auth token
- save ONG when creating medical records and doctor-patient relations
- sync DB with `alter: true` so new columns are added

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f1e786c0c83318816fd952258ee8b