### PR TITLE
Include ongId in auth flow

### DIFF
--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -10,7 +10,8 @@ module.exports = (req, res, next) => {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
-    req.user = decoded;
+    const { id, role, ongId } = decoded;
+    req.user = { id, role, ongId };
     next();
   } catch (err) {
     console.error(err);

--- a/backend/routes/withdrawal.js
+++ b/backend/routes/withdrawal.js
@@ -9,7 +9,8 @@ const role = require('../middlewares/roleMiddleware');
 // Create withdrawal request
 router.post('/', auth, async (req, res) => {
   try {
-    const { amount, variety, ongId, reason } = req.body;
+    const { amount, variety, reason } = req.body;
+    const ongId = req.user.ongId;
     if (!amount || !variety || !ongId) {
       return res.status(400).json({ error: 'Missing fields' });
     }
@@ -69,11 +70,11 @@ router.get('/', auth, async (req, res) => {
 
     if (req.user.role !== 'admin') {
       where.userId = req.user.id;
-    } else if (userId) {
-      where.userId = userId;
+      where.ongId = req.user.ongId;
+    } else {
+      if (userId) where.userId = userId;
+      if (ongId) where.ongId = ongId;
     }
-
-    if (ongId) where.ongId = ongId;
     if (status) where.status = status;
 
     const result = await Withdrawal.findAndCountAll({


### PR DESCRIPTION
## Summary
- preserve `id`, `role` and `ongId` when decoding auth tokens
- use user's `ongId` when creating or listing withdrawals

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f2171eaf08331acb10ad1ee2975fb