### PR TITLE
Protect ONG creation and seed admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ cd backend
 npm install
 npm run sync-db
 npm run seed-roles
+npm run seed-admin
 npm start
 ```
 El script `npm run seed-roles` crea los roles básicos en la base de datos.
+`npm run seed-admin` agrega un usuario administrador por defecto
+(`admin@example.com` / `admin123`).
 
 ## Iniciar el frontend
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "sync-db": "node sync.js",
     "seed-roles": "node seed-roles.js",
+    "seed-admin": "node seed-admin.js",
     "start": "node index.js"
   },
   "keywords": [],

--- a/backend/routes/ong.js
+++ b/backend/routes/ong.js
@@ -41,8 +41,8 @@ router.get('/', auth, role(['admin']), async (req, res) => {
   }
 });
 
-// Register ONG
-router.post('/', upload.fields([{ name: 'statute', maxCount: 1 }, { name: 'documents', maxCount: 1 }]), async (req, res) => {
+// Register ONG (admin only)
+router.post('/', auth, role(['admin']), upload.fields([{ name: 'statute', maxCount: 1 }, { name: 'documents', maxCount: 1 }]), async (req, res) => {
   try {
     const { name, description, phone, email, address } = req.body;
     const statute = req.files['statute'] ? req.files['statute'][0].filename : null;

--- a/backend/seed-admin.js
+++ b/backend/seed-admin.js
@@ -1,0 +1,33 @@
+require('dotenv').config();
+const bcrypt = require('bcrypt');
+const { User, Role, sequelize } = require('./models');
+
+(async () => {
+  try {
+    const adminRole = await Role.findOne({ where: { name: 'admin' } });
+    if (!adminRole) {
+      console.error("Rol 'admin' no encontrado. Ejecuta primero seed-roles.");
+      return;
+    }
+
+    const hashedPassword = await bcrypt.hash('admin123', 10);
+    const [user, created] = await User.findOrCreate({
+      where: { email: 'admin@example.com' },
+      defaults: {
+        name: 'Admin',
+        password: hashedPassword,
+        roleId: adminRole.id,
+      },
+    });
+
+    if (created) {
+      console.log("Usuario administrador creado: admin@example.com / admin123");
+    } else {
+      console.log('El usuario administrador ya existe');
+    }
+  } catch (err) {
+    console.error('Error al crear usuario administrador:', err);
+  } finally {
+    await sequelize.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- secure `POST /ongs` with auth and admin role checks
- add script to create a default admin user
- expose new `seed-admin` npm script
- document admin seeding in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f26af40248331a18d126df1604dc3