### PR TITLE
Enforce ONG ownership checks

### DIFF
--- a/backend/middlewares/ongMatchMiddleware.js
+++ b/backend/middlewares/ongMatchMiddleware.js
@@ -1,0 +1,15 @@
+module.exports = (...fields) => {
+  return (req, res, next) => {
+    if (!req.user || req.user.ongId == null) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const ongId = parseInt(req.user.ongId);
+    for (const field of fields) {
+      const value = req.params[field] ?? req.body[field] ?? req.query[field];
+      if (value !== undefined && parseInt(value) !== ongId) {
+        return res.status(403).json({ error: 'ONG mismatch' });
+      }
+    }
+    next();
+  };
+};


### PR DESCRIPTION
## Summary
- add middleware for verifying ONG ownership
- require patient ONG match on doctor routes
- verify patient ONG on legal record uploads and queries
- enforce ONG ownership on withdrawal routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f279ef3b883319e0b7bb306fb34ec