### PR TITLE
Implement ONG-aware user registration

### DIFF
--- a/frontend/src/pages/AdminPage.js
+++ b/frontend/src/pages/AdminPage.js
@@ -1,10 +1,13 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { AuthContext } from '../context/AuthContext';
 import { apiFetch } from '../services/api';
+import { parseJwt } from '../utils/jwt';
 
 export default function AdminPage() {
   const { token } = useContext(AuthContext);
   const [users, setUsers] = useState([]);
+  const [form, setForm] = useState({ name: '', email: '', password: '', role: '' });
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     apiFetch('/users', { token })
@@ -12,9 +15,62 @@ export default function AdminPage() {
       .catch(() => {});
   }, [token]);
 
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const payload = parseJwt(token);
+      await apiFetch('/auth/register', {
+        method: 'POST',
+        token,
+        body: JSON.stringify({ ...form, ongId: payload?.ongId })
+      });
+      setForm({ name: '', email: '', password: '', role: '' });
+      apiFetch('/users', { token })
+        .then(data => setUsers(data.data || []))
+        .catch(() => {});
+    } catch (err) {
+      setError('Error al registrar');
+    }
+  };
+
   return (
     <div>
       <h2>Área Administrador</h2>
+      <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+        <input
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="Nombre"
+        />
+        <input
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="Email"
+        />
+        <input
+          type="password"
+          name="password"
+          value={form.password}
+          onChange={handleChange}
+          placeholder="Contraseña"
+        />
+        <input
+          name="role"
+          value={form.role}
+          onChange={handleChange}
+          placeholder="Rol"
+        />
+        <button type="submit">Registrar</button>
+        {error && <span>{error}</span>}
+      </form>
       <ul>
         {users.map(u => (
           <li key={u.id}>{u.name}</li>


### PR DESCRIPTION
## Summary
- secure user registration with auth, admin role and ONG validation
- include ongId in User.create
- extend admin page to register users and send ongId from token

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f29d29ee48331a12caf586ec20cf1