### PR TITLE
Introduce admin_ong role

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ npm run seed-admin
 npm start
 ```
 El script `npm run seed-roles` crea los roles básicos en la base de datos.
-`npm run seed-admin` agrega un usuario administrador por defecto
-(`admin@example.com` / `admin123`).
+`npm run seed-admin` agrega usuarios de ejemplo:
+- Administrador global (`admin@example.com` / `admin123`)
+- Administrador de ONG (`admin_ong@example.com` / `adminong123`).
 
 ## Iniciar el frontend
 
@@ -45,7 +46,8 @@ Asegúrate de que `REACT_APP_API_URL` apunte a la URL del backend.
 ```
 
 ## Roles
-- **Admin**: gestiona usuarios, aprueba o rechaza ONGs y retiros y accede a las estadísticas del sistema.
+- **Admin**: gestiona ONGs y accede a las estadísticas globales del sistema.
+- **Admin ONG**: administra los usuarios y retiros de su propia ONG.
 - **Doctor**: administra sus pacientes, puede asociarlos y subir documentos médicos y legales.
 - **Legal**: consulta los registros legales cargados.
 - **Paciente**: accede a su área personal y puede solicitar retiros.

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -9,7 +9,7 @@ const role = require('../middlewares/roleMiddleware');
 const checkOng = require('../middlewares/ongMatchMiddleware');
 
 // User registration
-router.post('/register', auth, role(['admin']), checkOng('ongId'), async (req, res) => {
+router.post('/register', auth, role(['admin_ong']), checkOng('ongId'), async (req, res) => {
   try {
     const { name, email, password, role: roleName, ongId } = req.body;
     if (!name || !email || !password || !roleName || !ongId) {

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -6,7 +6,7 @@ const auth = require('../middlewares/authMiddleware');
 const role = require('../middlewares/roleMiddleware');
 
 // List users with filters and pagination (admin only)
-router.get('/', auth, role(['admin']), async (req, res) => {
+router.get('/', auth, role(['admin_ong']), async (req, res) => {
   try {
     const { page = 1, limit = 10, name, email, roleId } = req.query;
     const where = {};

--- a/backend/routes/withdrawal.js
+++ b/backend/routes/withdrawal.js
@@ -40,7 +40,7 @@ router.post('/', auth, checkOng('ongId'), async (req, res) => {
 });
 
 // Update withdrawal status (admin only)
-router.put('/:id', auth, role(['admin']), async (req, res) => {
+router.put('/:id', auth, role(['admin_ong']), async (req, res) => {
   try {
     const { status } = req.body;
     const withdrawal = await Withdrawal.findByPk(req.params.id);
@@ -72,7 +72,7 @@ router.get('/', auth, checkOng('ongId'), async (req, res) => {
     const { page = 1, limit = 10, status, userId, ongId } = req.query;
     const where = {};
 
-    if (req.user.role !== 'admin') {
+    if (req.user.role !== 'admin_ong') {
       where.userId = req.user.id;
       where.ongId = req.user.ongId;
     } else {

--- a/backend/seed-admin.js
+++ b/backend/seed-admin.js
@@ -5,8 +5,9 @@ const { User, Role, sequelize } = require('./models');
 (async () => {
   try {
     const adminRole = await Role.findOne({ where: { name: 'admin' } });
-    if (!adminRole) {
-      console.error("Rol 'admin' no encontrado. Ejecuta primero seed-roles.");
+    const adminOngRole = await Role.findOne({ where: { name: 'admin_ong' } });
+    if (!adminRole || !adminOngRole) {
+      console.error("Roles requeridos no encontrados. Ejecuta primero seed-roles.");
       return;
     }
 
@@ -24,6 +25,25 @@ const { User, Role, sequelize } = require('./models');
       console.log("Usuario administrador creado: admin@example.com / admin123");
     } else {
       console.log('El usuario administrador ya existe');
+    }
+
+    const hashedAdminOngPassword = await bcrypt.hash('adminong123', 10);
+    const [adminOng, adminOngCreated] = await User.findOrCreate({
+      where: { email: 'admin_ong@example.com' },
+      defaults: {
+        name: 'Admin ONG',
+        password: hashedAdminOngPassword,
+        roleId: adminOngRole.id,
+        ongId: 1,
+      },
+    });
+
+    if (adminOngCreated) {
+      console.log(
+        "Usuario admin_ong creado: admin_ong@example.com / adminong123"
+      );
+    } else {
+      console.log('El usuario admin_ong ya existe');
     }
   } catch (err) {
     console.error('Error al crear usuario administrador:', err);

--- a/backend/seed-roles.js
+++ b/backend/seed-roles.js
@@ -3,7 +3,7 @@ const { Role, sequelize } = require('./models');
 
 (async () => {
   try {
-    const basicRoles = ['admin', 'doctor', 'legal', 'paciente'];
+    const basicRoles = ['admin', 'doctor', 'legal', 'paciente', 'admin_ong'];
     for (const name of basicRoles) {
       const [role, created] = await Role.findOrCreate({ where: { name } });
       if (created) {


### PR DESCRIPTION
## Summary
- create `admin_ong` role in role seed script
- seed example `admin_ong` user
- guard registration, user list and withdrawal status with `admin_ong`
- document the new role and seed accounts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f2b9a6fc88331b928b810123df2fe