### PR TITLE
Add ONG-based filter to stats

### DIFF
--- a/backend/middlewares/ongMatchMiddleware.js
+++ b/backend/middlewares/ongMatchMiddleware.js
@@ -1,8 +1,18 @@
 module.exports = (...fields) => {
   return (req, res, next) => {
-    if (!req.user || req.user.ongId == null) {
+    if (!req.user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
+
+    // Global admin can access any ONG so skip checks
+    if (req.user.role === 'admin') {
+      return next();
+    }
+
+    if (req.user.ongId == null) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
     const ongId = parseInt(req.user.ongId);
     for (const field of fields) {
       const value = req.params[field] ?? req.body[field] ?? req.query[field];


### PR DESCRIPTION
## Summary
- allow global admin to bypass ONG check
- restrict stats queries by ONG for NGO admins
- export stats per ONG only

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f2d083d448331b475ec8a755719a1