### PR TITLE
Add Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,15 @@ Asegúrate de que `REACT_APP_API_URL` apunte a la URL del backend.
 ### Documentación legal
 1. Un médico sube archivos mediante `POST /legal-records`.
 2. Cualquier usuario autenticado puede consultar los registros con `GET /legal-records/:patientId`.
+
+## Ejecutar con Docker
+
+Para levantar todo el entorno (base de datos, backend y frontend) se utiliza `docker-compose`:
+
+```bash
+docker-compose build
+docker-compose up
+```
+
+El frontend quedará disponible en `http://localhost:3001` y el backend en `http://localhost:3000`.
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3.8'
+
+services:
+  db:
+    image: mariadb:10
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: accama
+    volumes:
+      - db-data:/var/lib/mysql
+    networks:
+      - app
+
+  backend:
+    build: ./backend
+    environment:
+      PORT: 3000
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_NAME: accama
+      DB_USER: root
+      DB_PASSWORD: root
+      JWT_SECRET: changeme
+    depends_on:
+      - db
+    ports:
+      - "3000:3000"
+    networks:
+      - app
+
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        REACT_APP_API_URL: http://backend:3000
+    depends_on:
+      - backend
+    ports:
+      - "3001:80"
+    networks:
+      - app
+
+volumes:
+  db-data:
+
+networks:
+  app:
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:18 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+ARG REACT_APP_API_URL
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- create Dockerfile for backend
- create Dockerfile for frontend
- add docker-compose.yml to run MariaDB, backend and frontend
- document Docker usage in README

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f2ecdd468833184b4311a642dd748