### PR TITLE
Fix auth context persistence

### DIFF
--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect } from 'react';
+import React, { createContext, useState } from 'react';
 import { parseJwt } from '../utils/jwt';
 
 export const AuthContext = createContext({
@@ -10,8 +10,13 @@ export const AuthContext = createContext({
 });
 
 export function AuthProvider({ children }) {
-  const [token, setToken] = useState(null);
-  const [role, setRole] = useState(null);
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+  const [role, setRole] = useState(() => {
+    const stored = localStorage.getItem('token');
+    if (!stored) return null;
+    const payload = parseJwt(stored);
+    return payload?.role || null;
+  });
 
   const login = (newToken, newRole) => {
     setToken(newToken);
@@ -31,12 +36,11 @@ export function AuthProvider({ children }) {
       setToken(stored);
       const payload = parseJwt(stored);
       setRole(payload?.role || null);
+    } else {
+      setToken(null);
+      setRole(null);
     }
   };
-
-  useEffect(() => {
-    loadFromStorage();
-  }, []);
 
   return (
     <AuthContext.Provider value={{ token, role, login, logout, loadFromStorage }}>


### PR DESCRIPTION
## Summary
- read token and role from `localStorage` on AuthContext init
- remove effect that triggered `loadFromStorage`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3fe26a4883318b9fcda4c23fb2c9